### PR TITLE
Password is required when getting Friend Requests.

### DIFF
--- a/endpoints/boomlings.com/database/getGJFriendRequests20.md
+++ b/endpoints/boomlings.com/database/getGJFriendRequests20.md
@@ -6,6 +6,7 @@ Gets all friend requests from an account going in and out.
 #### binaryVersion
 #### gdw
 #### accountID
+#### gjp
 #### page
 The page offset you want to see. The offset is 10 per page.
 #### total


### PR DESCRIPTION
A password IS required when sending friend requests, while the documentation doesn't view this change. This pull request adds this infomation to the documentation